### PR TITLE
Fix version conflicts caused by PR#56

### DIFF
--- a/MLSample.TransactionTagging.Core/MLSample.TransactionTagging.Core.csproj
+++ b/MLSample.TransactionTagging.Core/MLSample.TransactionTagging.Core.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ML" Version="1.5.2" />
-    <PackageReference Include="Microsoft.ML.AutoML" Version="0.17.2" />
+    <PackageReference Include="Microsoft.ML" Version="1.6.0" />
+    <PackageReference Include="Microsoft.ML.AutoML" Version="0.18.0" />
   </ItemGroup>
 
 </Project>

--- a/MLSample.TransactionTagging/MLSample.TransactionTagging.csproj
+++ b/MLSample.TransactionTagging/MLSample.TransactionTagging.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ML" Version="1.5.2" />
+    <PackageReference Include="Microsoft.ML" Version="1.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Microsoft.ML.AutoML from 0.17.2 to 0.18.0. [(PR#56)](https://github.com/jernejk/MLSample.SimpleTransactionTagging/pull/56).
Hope this fix can help you.

Best regards,
sucrose